### PR TITLE
Login

### DIFF
--- a/app/controllers/api/v1/sessions_controller.rb
+++ b/app/controllers/api/v1/sessions_controller.rb
@@ -1,0 +1,17 @@
+class Api::V1::SessionsController < ApplicationController
+  def create
+    user = User.find_by(email: user_params[:email])
+    if user && user.authenticate(user_params[:password])
+      render json: SuccessfulLoginSerializer.new(user), status: 200
+    else
+      unsuccessful = ErrorMessage.new(user)
+      render json: FailedLoginSerializer.new(unsuccessful), status: 401
+    end
+  end
+
+  private
+
+  def user_params
+    params.permit(:email, :password)
+  end
+end

--- a/app/poros/error_message.rb
+++ b/app/poros/error_message.rb
@@ -10,6 +10,10 @@ class ErrorMessage
     user.errors
   end
 
+  def invalid_credentials
+    'Invalid email or password'
+  end
+
   private
 
   attr_reader :user

--- a/app/serializers/failed_login_serializer.rb
+++ b/app/serializers/failed_login_serializer.rb
@@ -1,0 +1,4 @@
+class FailedLoginSerializer
+  include FastJsonapi::ObjectSerializer
+  attributes :invalid_credentials
+end

--- a/app/serializers/successful_login_serializer.rb
+++ b/app/serializers/successful_login_serializer.rb
@@ -1,0 +1,4 @@
+class SuccessfulLoginSerializer
+  include FastJsonapi::ObjectSerializer
+  attributes :api_key
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,7 @@ Rails.application.routes.draw do
       get '/forecast', to: 'forecast#index'
       get '/backgrounds', to: 'backgrounds#index'
       post '/users', to: 'users#create'
+      post '/sessions', to: 'sessions#create'
     end
   end
 end

--- a/spec/requests/api/v1/login_request_spec.rb
+++ b/spec/requests/api/v1/login_request_spec.rb
@@ -1,0 +1,43 @@
+require 'rails_helper'
+
+describe 'Login API endpoint' do
+  it 'successful login returns api key for associated user' do
+    User.create(
+      email: 'whatever@example.com',
+      password: 'password',
+      password_confirmation: 'password'
+    )
+
+    headers = { CONTENT_TYPE: 'application/json', ACCEPT: 'application/json' }
+    params = { email: 'whatever@example.com', password: 'password' }
+
+    post '/api/v1/sessions', params: params
+
+    expect(response).to be_successful
+
+    parsed_json = JSON.parse(response.body, symbolize_names: true)
+
+    expect(parsed_json[:data][:attributes]).to have_key(:api_key)
+    expect(parsed_json[:data][:attributes][:api_key]).to_not eq(nil)
+  end
+
+  it 'returns 400 level status code and invalid credentials response for invalid email/password combination' do
+    User.create(
+      email: 'whatever@example.com',
+      password: 'password',
+      password_confirmation: 'password'
+    )
+
+    headers = { CONTENT_TYPE: 'application/json', ACCEPT: 'application/json' }
+    params = { email: 'whatever@example.com', password: 'invalid_password' }
+
+    post '/api/v1/sessions', params: params
+
+    expect(response).to_not be_successful
+
+    parsed_json = JSON.parse(response.body, symbolize_names: true)
+    invalid_credentials_error = parsed_json[:data][:attributes][:invalid_credentials]
+
+    expect(invalid_credentials_error).to eq('Invalid email or password')
+  end
+end


### PR DESCRIPTION
- Successful login request returns user’s api key
- Unsuccessful request returns 401 status code and invalid credentials response
- Create test for API login endpoint
- Add route for sessions controller create action: `POST /api/v1/sessions`
- Build out create action in sessions controller
- Create successful and failed login serializers
- Add `invalid_credentials` method to `ErrorMessage` PORO
- All tests passing